### PR TITLE
Add support for noisy rates with a fuzz value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following environment variables can be set to modify the output.
 | PUT_PERCENT       | 0       | Percentage of requests that will be `PUT` requests. If the total adds up to less than 100%, the rest will be made up of random HTTP methods.    |
 | PATCH_PERCENT     | 0       | Percentage of requests that will be `PATCH` requests. If the total adds up to less than 100%, the rest will be made up of random HTTP methods.  |
 | DELETE_PERCENT    | 0       | Percentage of requests that will be `DELETE` requests. If the total adds up to less than 100%, the rest will be made up of random HTTP methods. |
+| FUZZ              | 0       | Determines the amount of random variation in the rate of log generation, in seconds. |
 
 ## Note
 


### PR DESCRIPTION
This PR implements a very simple method to allow the log rate to vary over time. The fuzz variable indicates how much time might be added or subtracted from the interval. This increases the ability to use the generator to test tools that show the rate of logs over time. Code review welcome, I'm new to Go.

Closes #4.